### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 GeneticSharp
 ===========
 
-####Build
+#### Build
 [![Build status](https://ci.appveyor.com/api/projects/status/h9ptxpyj30ah3mva/branch/master?svg=true)](https://ci.appveyor.com/project/giacomelli/geneticsharp)
 
-####Code quality
+#### Code quality
 [![Coverage Status](https://coveralls.io/repos/giacomelli/GeneticSharp/badge.svg?branch=master&service=github)](https://coveralls.io/github/giacomelli/GeneticSharp?branch=master)
 [![FxCop](http://badgessharp.apphb.com/badges/giacomelli/GeneticSharp/FxCop)](https://ci.appveyor.com/project/giacomelli/GeneticSharp/build/artifacts)
 [![DupFinder](http://badgessharp.apphb.com/badges/giacomelli/GeneticSharp/DupFinder)](https://ci.appveyor.com/project/giacomelli/GeneticSharp/build/artifacts)
 
-####Release
+#### Release
 [![License](http://img.shields.io/:license-MIT-blue.svg)](https://raw.githubusercontent.com/giacomelli/GeneticSharp/master/LICENSE)
 [![Nuget](https://img.shields.io/nuget/v/GeneticSharp.svg)](https://www.nuget.org/packages/GeneticSharp/)
 [![Stack Overflow](https://img.shields.io/badge/stackoverflow-GeneticSharp-orange.svg)](http://stackoverflow.com/questions/tagged/GeneticSharp)
@@ -21,35 +21,35 @@ Can be used in any kind of .NET apps, like ASP .NET MVC, Web Forms, Windows Form
 
 --------
 
-##Projects and papers using GeneticSharp
+## Projects and papers using GeneticSharp
 * [AeroVision: aircraft trajectories optimization and visualization](https://github.com/giacomelli/GeneticSharp/blob/master/docs/mentioning-GeneticSharp/AeroVision-Aircraft-trajectories-optimization-and-visualization.pdf)
 * [Designing and creating a self managing distributed file system](https://github.com/giacomelli/GeneticSharp/blob/master/docs/mentioning-GeneticSharp/Designing-and-creating-a-self-managing-distributed-file-system.pdf)
 * [Path Finding with Genetic Algorithms](https://yoloprogramming.com/post/2017/01/11/path-finding-with-genetic-algorithms)
 * [SurvivorAI: some experiments of survival scenarios](https://github.com/giacomelli/SurvivorAI)
 * Are you using GeneticSharp in your project? Please, [let me know!](https://twitter.com/ogiacomelli)
 
-##Features
+## Features
 
-###[Chromosomes](src/GeneticSharp.Domain/Chromosomes)
+### [Chromosomes](src/GeneticSharp.Domain/Chromosomes)
 Add your own chromosome representation implementing [IChromosome](src/GeneticSharp.Domain/Chromosomes/IChromosome.cs) interface or extending [ChromosomeBase](src/GeneticSharp.Domain/Chromosomes/ChromosomeBase.cs)   
    
-###[Fitness](src/GeneticSharp.Domain/Fitnesses)
+### [Fitness](src/GeneticSharp.Domain/Fitnesses)
 Add your own fitness evaluation, implementing [IFitness](src/GeneticSharp.Domain/Fitnesses/IFitness.cs) interface.
 
-###[Populations](src/GeneticSharp.Domain/Populations)
+### [Populations](src/GeneticSharp.Domain/Populations)
    - [Generation](src/GeneticSharp.Domain/Populations/Generation.cs)
    - [Generation strategy](src/GeneticSharp.Domain/Populations/IGenerationStrategy.cs)
      - [Performance strategy](src/GeneticSharp.Domain/Populations/PerformanceGenerationStrategy.cs)
      - [Tracking strategy](src/GeneticSharp.Domain/Populations/TrackingGenerationStrategy.cs)  
 
-###[Selections](src/GeneticSharp.Domain/Selections)
+### [Selections](src/GeneticSharp.Domain/Selections)
    - [Elite](src/GeneticSharp.Domain/Selections/EliteSelection.cs) (also know as Truncate or Truncation)
    - [Roulette Wheel](src/GeneticSharp.Domain/Selections/RouletteWheelSelection.cs)
    - [Stochastic Universal Sampling](src/GeneticSharp.Domain/Selections/StochasticUniversalSamplingSelection.cs)
    - [Tournament](src/GeneticSharp.Domain/Selections/TournamentSelection.cs)  
    - Others selections can be added implementing [ISelection](src/GeneticSharp.Domain/Selections/ISelection.cs) interface or extending [SelectionBase](src/GeneticSharp.Domain/Selections/SelectionBase.cs). 
 
-###[Crossovers](src/GeneticSharp.Domain/Crossovers)
+### [Crossovers](src/GeneticSharp.Domain/Crossovers)
    - [Cut and Splice](src/GeneticSharp.Domain/Crossovers/CutAndSpliceCrossover.cs) 
    - [Cycle (CX)](src/GeneticSharp.Domain/Crossovers/CycleCrossover.cs)   
    - [One-Point (C1)](src/GeneticSharp.Domain/Crossovers/OnePointCrossover.cs)
@@ -62,20 +62,20 @@ Add your own fitness evaluation, implementing [IFitness](src/GeneticSharp.Domain
    - [Uniform](src/GeneticSharp.Domain/Crossovers/UniformCrossover.cs)
    - Others crossovers can be added implementing [ICrossover](src/GeneticSharp.Domain/Crossovers/ICrossover.cs) interface or extending [CrossoverBase](src/GeneticSharp.Domain/Crossovers/CrossoverBase.cs).   
 
-###[Mutations](src/GeneticSharp.Domain/Mutations)
+### [Mutations](src/GeneticSharp.Domain/Mutations)
    - [Reverse Sequence (RSM)](src/GeneticSharp.Domain/Mutations/ReverseSequenceMutation.cs)
    - [Twors](src/GeneticSharp.Domain/Mutations/TworsMutation.cs)
    - [Uniform](src/GeneticSharp.Domain/Mutations/UniformMutation.cs)
    - Others mutations can be added implementing [IMutation](src/GeneticSharp.Domain/Mutations/IMutation.cs) interface or extending [MutationBase](src/GeneticSharp.Domain/Mutations/MutationBase.cs).
 
-###[Reinsertions](src/GeneticSharp.Domain/Reinsertions)
+### [Reinsertions](src/GeneticSharp.Domain/Reinsertions)
    - [Elitist](src/GeneticSharp.Domain/Reinsertions/ElitistReinsertion.cs)
    - [Fitness Based](src/GeneticSharp.Domain/Reinsertions/FitnessBasedReinsertion.cs)
    - [Pure](src/GeneticSharp.Domain/Reinsertions/PureReinsertion.cs)
    - [Uniform](src/GeneticSharp.Domain/Reinsertions/UniformReinsertion.cs)
    - Others reinsertions can be added implementing [IReinsertion](src/GeneticSharp.Domain/Reinsertions/IReinsertion.cs) interface or extending [ReinsertionBase](src/GeneticSharp.Domain/Reinsertions/ReinsertionBase.cs).
 
-###[Terminations](src/GeneticSharp.Domain/Terminations)
+### [Terminations](src/GeneticSharp.Domain/Terminations)
    - [Generation number](src/GeneticSharp.Domain/Terminations/GenerationNu)
    - [Time evolving](src/GeneticSharp.Domain/Terminations/TimeEvolvingTermination.cs)
    - [Fitness stagnation](src/GeneticSharp.Domain/Terminations/FitnessStagnationTermination.cs)
@@ -83,12 +83,12 @@ Add your own fitness evaluation, implementing [IFitness](src/GeneticSharp.Domain
    - [And](src/GeneticSharp.Domain/Terminations/AndTermination.cs) e [Or](src/GeneticSharp.Domain/Terminations/OrTermination.cs) (allows combine others terminations)
    - Others terminations can be added implementing [ITermination](src/GeneticSharp.Domain/Terminations/ITermination.cs) interface or extending [TerminationBase](src/GeneticSharp.Domain/Terminations/TerminationBase.cs).
 
-###[Randomizations](src/GeneticSharp.Domain/Randomizations)
+### [Randomizations](src/GeneticSharp.Domain/Randomizations)
    - [Basic randomization](src/GeneticSharp.Domain/Randomizations/BasicRandomization.cs) (using System.Random)
    - [Fast random](src/GeneticSharp.Domain/Randomizations/FastRandomRandomization.cs)   
    - If you need a special kind of randomization for your GA, just implement the [IRandomization](src/GeneticSharp.Domain/Randomizations/IRandomization.cs) interface.
 
-###[Runner app (console)](src/GeneticSharp.Runner.ConsoleApp) with samples
+### [Runner app (console)](src/GeneticSharp.Runner.ConsoleApp) with samples
 - AutoConfig
 - Bitmap equality
 - Equality equation
@@ -99,22 +99,22 @@ Add your own fitness evaluation, implementing [IFitness](src/GeneticSharp.Domain
 - Ghostwriter
 - TSP (Travelling Salesman Problem)
  	
-###[Runner app (GTK#)](src/GeneticSharp.Runner.GtkApp) with visual samples:
+### [Runner app (GTK#)](src/GeneticSharp.Runner.GtkApp) with visual samples:
 
-####TSP (Travelling Salesman Problem).
+#### TSP (Travelling Salesman Problem).
 ![](docs/screenshots/GtkApp.Samples.TSP.Win.png)
  
-####Bitmap equality
+#### Bitmap equality
 ![](docs/gifs/GeneticSharp-BitmapEquality_sample01.gif) 
 
       
-###Multi-platform
+### Multi-platform
 - Mono support.
 - Fully tested on Windows and MacOSX.
       ![](docs/screenshots/XamarinStudio.png) 
       ![](docs/screenshots/VisualStudio.png) 
 
-###Code quality
+### Code quality
 - 100% unit test code coverage.
 - FxCop validated.
 - Code duplicated verification.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
