### PR TITLE
exception for fitness <=0

### DIFF
--- a/src/GeneticSharp.Domain/Fitnesses/FuncFitness.cs
+++ b/src/GeneticSharp.Domain/Fitnesses/FuncFitness.cs
@@ -28,7 +28,12 @@ namespace GeneticSharp.Domain.Fitnesses
         /// <param name="chromosome">Chromosome.</param>
         public double Evaluate (IChromosome chromosome)
         {
-            return m_func (chromosome);
+            double score = m_func (chromosome);
+            if (score <= 0.0)
+            {
+                throw new Exception("Chromosome fitness must give a score greater than zero");
+            }
+            return score;
         }
         #endregion
     }


### PR DESCRIPTION
The chromosome cannot be selected (at least in RouletteWheelSelection), resulting in a population of even only 1 chromosome.