### PR TITLE
Fix for #70 unintentional ref comparison

### DIFF
--- a/src/GeneticSharp.Domain/Populations/Population.cs
+++ b/src/GeneticSharp.Domain/Populations/Population.cs
@@ -146,7 +146,7 @@ namespace GeneticSharp
         {
             CurrentGeneration.End(MaxSize);
 
-            if (BestChromosome != CurrentGeneration.BestChromosome)
+            if (BestChromosome == null || BestChromosome.CompareTo(CurrentGeneration.BestChromosome) != 0)
             {
                 BestChromosome = CurrentGeneration.BestChromosome;
 

--- a/src/GeneticSharp.Extensions/Checkers/CheckersSquare.cs
+++ b/src/GeneticSharp.Extensions/Checkers/CheckersSquare.cs
@@ -120,7 +120,7 @@ namespace GeneticSharp.Extensions
         {
             if (CurrentPiece != null)
             {
-                if (CurrentPiece.CurrentSquare == this)
+                if (Equals(CurrentPiece.CurrentSquare, this))
                 {
                     CurrentPiece.CurrentSquare = null;
                 }


### PR DESCRIPTION
As discussed in #70 I changed the best chromosome comparision to use `IComparable`

I also fixed a similar warning in [CheckersSquare.cs](https://github.com/giacomelli/GeneticSharp/blob/master/src/GeneticSharp.Extensions/Checkers/CheckersSquare.cs#L123)