### PR TITLE
Fix GTK# installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,4 @@ BenchmarkDotNet.Artifacts
 !/tools/buildTemplatesNuget.cmd
 !/tools/runBenchmarks.cmd
 !/tools/runBenchmarks.sh
+*.msi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ assembly_info:
   assembly_informational_version: '{version}'
   
 install:
-- cmd: choco install gtksharp
+- cmd: ./install-gtksharp.ps1
 - cmd: dotnet tool install --global Cake.Tool
   
 before_build:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ assembly_info:
   assembly_informational_version: '{version}'
   
 install:
-- cmd: ./install-gtksharp.ps1
+- ps: install-gtksharp.ps1
 - cmd: dotnet tool install --global Cake.Tool
   
 before_build:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ assembly_info:
   assembly_informational_version: '{version}'
   
 install:
-- ps: install-gtksharp.ps1
+- ps: ./install-gtksharp.ps1
 - cmd: dotnet tool install --global Cake.Tool
   
 before_build:

--- a/build.cake
+++ b/build.cake
@@ -1,5 +1,5 @@
 #tool "nuget:?package=MSBuild.SonarQube.Runner.Tool&version=4.8.0"
-#addin "nuget:?package=Cake.Sonar&version=1.1.30"
+#addin "nuget:?package=Cake.Sonar&version=1.1.31"
 #addin "nuget:?package=Cake.Git&version=2.0.0"
 
 var target = Argument("target", "Default");

--- a/install-gtksharp.ps1
+++ b/install-gtksharp.ps1
@@ -1,11 +1,12 @@
-Write-Output "Downloading installer..."
+Write-Output "INSTALLING GTK#"
+Write-Output "  Downloading installer..."
 Invoke-WebRequest -uri https://github.com/mono/gtk-sharp/releases/download/2.12.45/gtk-sharp-2.12.45.msi -OutFile ./gtk-sharp-2.12.45.msi 
 
-Write-Output "Starting installer..."
+Write-Output "  Starting installer..."
 ./gtk-sharp-2.12.45.msi /quiet /qn /norestart
 
-Write-Output "Waiting for installer finish..."
+Write-Output "  Waiting for installer finish..."
 Start-Sleep 10
 Wait-Process -Name "msiexec" -Timeout 300
 
-Write-Output "Done."
+Write-Output "GTK# INSTALLED"

--- a/install-gtksharp.ps1
+++ b/install-gtksharp.ps1
@@ -1,0 +1,11 @@
+Write-Output "Downloading installer..."
+Invoke-WebRequest -uri https://github.com/mono/gtk-sharp/releases/download/2.12.45/gtk-sharp-2.12.45.msi -OutFile ./gtk-sharp-2.12.45.msi 
+
+Write-Output "Starting installer..."
+./gtk-sharp-2.12.45.msi /quiet /qn /norestart
+
+Write-Output "Waiting for installer finish..."
+Start-Sleep 10
+Wait-Process -Name "msiexec" -Timeout 300
+
+Write-Output "Done."


### PR DESCRIPTION
GTK# installation was done using the `choco install gtksharp`, but that Chocolatey package is pointing to .msi URL that does not exist anymore.

I've changed to directly download and install the GTK#.

Fix #103.