### PR TITLE
Enable nullable reference types for core projects

### DIFF
--- a/src/GeneticSharp.Domain/Chromosomes/BinaryChromosomeBase.cs
+++ b/src/GeneticSharp.Domain/Chromosomes/BinaryChromosomeBase.cs
@@ -28,7 +28,7 @@ namespace GeneticSharp
         /// <param name="index">The gene index.</param>
         public virtual void FlipGene (int index)    
         {
-            var value = (int) GetGene (index).Value;
+            var value = (int)GetGene(index).Value!;
 
             ReplaceGene (index, new Gene (value == 0 ? 1 : 0));
         }
@@ -49,7 +49,7 @@ namespace GeneticSharp
         /// <returns>A <see cref="System.String"/> that represents the current <see cref="GeneticSharp.BinaryChromosomeBase"/>.</returns>
         public override string ToString ()
         {
-            return String.Join (string.Empty, GetGenes ().Select (g => g.Value.ToString()).ToArray());
+            return String.Join (string.Empty, GetGenes ().Select (g => g.Value!.ToString()).ToArray());
         }
         #endregion
     }

--- a/src/GeneticSharp.Domain/Chromosomes/ChromosomeBase.cs
+++ b/src/GeneticSharp.Domain/Chromosomes/ChromosomeBase.cs
@@ -231,7 +231,7 @@ namespace GeneticSharp
         /// </summary>
         /// <returns>The to.</returns>
         /// <param name="other">The other chromosome.</param>
-        public int CompareTo(IChromosome other)
+        public int CompareTo(IChromosome? other)
         {
             if (other == null)
             {
@@ -254,7 +254,7 @@ namespace GeneticSharp
         /// <param name="obj">The <see cref="System.Object"/> to compare with the current <see cref="GeneticSharp.ChromosomeBase"/>.</param>
         /// <returns><c>true</c> if the specified <see cref="System.Object"/> is equal to the current
         /// <see cref="GeneticSharp.ChromosomeBase"/>; otherwise, <c>false</c>.</returns>
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             var other = obj as IChromosome;
 

--- a/src/GeneticSharp.Domain/Chromosomes/FloatingPointChromosome.cs
+++ b/src/GeneticSharp.Domain/Chromosomes/FloatingPointChromosome.cs
@@ -58,7 +58,7 @@ namespace GeneticSharp
         /// <param name="totalBits">Total bits.</param>
         /// <param name="fractionDigits">Fraction digits.</param>
         /// /// <param name="geneValues">Gene values.</param>
-        public FloatingPointChromosome(double[] minValue, double[] maxValue, int[] totalBits, int[] fractionDigits, double[] geneValues)
+        public FloatingPointChromosome(double[] minValue, double[] maxValue, int[] totalBits, int[] fractionDigits, double[]? geneValues)
             : base(totalBits.Sum())
         {
             m_minValue = minValue;
@@ -152,7 +152,7 @@ namespace GeneticSharp
         /// <returns>A <see cref="T:System.String"/> that represents the current <see cref="T:GeneticSharp.Domain.Chromosomes.FloatingPointChromosome"/>.</returns>
         public override string ToString()
         {
-            return String.Join("", GetGenes().Select(g => g.Value.ToString()).ToArray());
+            return String.Join("", GetGenes().Select(g => g.Value!.ToString()).ToArray());
         }
     }
 }

--- a/src/GeneticSharp.Domain/Chromosomes/Gene.cs
+++ b/src/GeneticSharp.Domain/Chromosomes/Gene.cs
@@ -11,7 +11,7 @@ namespace GeneticSharp
     public struct Gene : IEquatable<Gene>
     {
         #region Fields
-        private object m_value;
+        private object? m_value;
         #endregion
 
         #region Constructors
@@ -19,7 +19,7 @@ namespace GeneticSharp
         /// Initializes a new instance of the <see cref="GeneticSharp.Gene"/> struct.
         /// </summary>
         /// <param name="value">The gene initial value.</param>
-        public Gene(object value)
+        public Gene(object? value)
         {
             m_value = value;
         }
@@ -31,7 +31,7 @@ namespace GeneticSharp
         /// Gets the value.
         /// </summary>
         /// <value>The value.</value>
-        public Object Value
+        public Object? Value
         {
             get
             {
@@ -73,7 +73,7 @@ namespace GeneticSharp
         /// <returns>A <see cref="System.String"/> that represents the current <see cref="GeneticSharp.Gene"/>.</returns>
         public override string ToString()
         {
-            return Value != null ? Value.ToString() : String.Empty;
+            return Value?.ToString() ?? string.Empty;
         }
 
         /// <summary>
@@ -96,7 +96,7 @@ namespace GeneticSharp
         /// <param name="obj">The <see cref="System.Object"/> to compare with the current <see cref="GeneticSharp.Gene"/>.</param>
         /// <returns><c>true</c> if the specified <see cref="System.Object"/> is equal to the current
         /// <see cref="GeneticSharp.Gene"/>; otherwise, <c>false</c>.</returns>
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (obj is Gene other)
             {

--- a/src/GeneticSharp.Domain/Chromosomes/IntegerChromosome.cs
+++ b/src/GeneticSharp.Domain/Chromosomes/IntegerChromosome.cs
@@ -56,7 +56,7 @@ namespace GeneticSharp
         public int ToInteger()
         {
             var array = new int[1];
-            var genes = GetGenes().Select(g => (bool)g.Value).ToArray();
+            var genes = GetGenes().Select(g => (bool)g.Value!).ToArray();
             var bitArray = new BitArray(genes);
             bitArray.CopyTo(array, 0);
 
@@ -69,7 +69,7 @@ namespace GeneticSharp
         /// <returns>A <see cref="T:System.String"/> that represents the current <see cref="T:GeneticSharp.Domain.Chromosomes.FloatingPointChromosome"/>.</returns>
         public override string ToString()
         {
-            return String.Join("", GetGenes().Reverse().Select(g => (bool) g.Value ? "1" : "0").ToArray());
+            return String.Join("", GetGenes().Reverse().Select(g => (bool)g.Value! ? "1" : "0").ToArray());
         }
 
         /// <summary>
@@ -81,7 +81,7 @@ namespace GeneticSharp
         public override void FlipGene(int index)
         {
             var realIndex = Math.Abs(31 - index);
-            var value = (bool)GetGene(realIndex).Value;
+            var value = (bool)GetGene(realIndex).Value!;
 
             ReplaceGene(realIndex, new Gene(!value));
         }

--- a/src/GeneticSharp.Domain/Crossovers/CrossoverException.cs
+++ b/src/GeneticSharp.Domain/Crossovers/CrossoverException.cs
@@ -75,7 +75,7 @@ namespace GeneticSharp
         /// Gets the crossover.
         /// </summary>
         /// <value>The crossover.</value>
-        public ICrossover Crossover { get; private set; }
+        public ICrossover? Crossover { get; private set; }
         #endregion
 
         #region Methods

--- a/src/GeneticSharp.Domain/Crossovers/CycleCrossover.cs
+++ b/src/GeneticSharp.Domain/Crossovers/CycleCrossover.cs
@@ -118,7 +118,7 @@ namespace GeneticSharp
             {
                 var parent2Gene = parent2Genes[geneIndex];
                 cycle.Add(geneIndex);
-                var newGeneIndex = parent1Genes.Select((g, i) => new { g.Value, Index = i }).First(g => g.Value.Equals(parent2Gene.Value));
+                var newGeneIndex = parent1Genes.Select((g, i) => new { g.Value, Index = i }).First(g => g.Value!.Equals(parent2Gene.Value));
 
                 if (geneIndex != newGeneIndex.Index)
                 {

--- a/src/GeneticSharp.Domain/Fitnesses/FitnessException.cs
+++ b/src/GeneticSharp.Domain/Fitnesses/FitnessException.cs
@@ -75,7 +75,7 @@ namespace GeneticSharp
         /// Gets the fitness.
         /// </summary>
         /// <value>The fitness.</value>
-        public IFitness Fitness { get; private set; }
+        public IFitness? Fitness { get; private set; }
         #endregion
 
         #region Methods

--- a/src/GeneticSharp.Domain/GeneticAlgorithm.cs
+++ b/src/GeneticSharp.Domain/GeneticAlgorithm.cs
@@ -114,17 +114,17 @@ namespace GeneticSharp
         /// <summary>
         /// Occurs when generation ran.
         /// </summary>
-        public event EventHandler GenerationRan;
+        public event EventHandler? GenerationRan;
 
         /// <summary>
         /// Occurs when termination reached.
         /// </summary>
-        public event EventHandler TerminationReached;
+        public event EventHandler? TerminationReached;
 
         /// <summary>
         /// Occurs when stopped.
         /// </summary>
-        public event EventHandler Stopped;
+        public event EventHandler? Stopped;
         #endregion
 
         #region Properties
@@ -196,7 +196,7 @@ namespace GeneticSharp
         /// Gets the best chromosome.
         /// </summary>
         /// <value>The best chromosome.</value>
-        public IChromosome BestChromosome
+        public IChromosome? BestChromosome
         {
             get
             {
@@ -221,12 +221,12 @@ namespace GeneticSharp
 
             private set
             {
-                var shouldStop = Stopped != null && m_state != value && value == GeneticAlgorithmState.Stopped;
+                var shouldStop = m_state != value && value == GeneticAlgorithmState.Stopped;
 
                 m_state = value;
 
                 if (shouldStop)
-                    Stopped.Invoke(this, EventArgs.Empty);
+                    Stopped?.Invoke(this, EventArgs.Empty);
             }
         }
 
@@ -393,7 +393,7 @@ namespace GeneticSharp
         {
             try
             {
-                var chromosomesWithoutFitness = Population.CurrentGeneration.Chromosomes.Where(c => !c.Fitness.HasValue).ToList();
+                var chromosomesWithoutFitness = Population.CurrentGeneration!.Chromosomes.Where(c => !c.Fitness.HasValue).ToList();
 
                 for (int i = 0; i < chromosomesWithoutFitness.Count; i++)
                 {
@@ -416,20 +416,18 @@ namespace GeneticSharp
                 TaskExecutor.Clear();
             }
 
-            Population.CurrentGeneration.Chromosomes = Population.CurrentGeneration.Chromosomes.OrderByDescending(c => c.Fitness.Value).ToList();
+            Population.CurrentGeneration.Chromosomes = Population.CurrentGeneration.Chromosomes.OrderByDescending(c => c.Fitness!.Value).ToList();
         }
 
         /// <summary>
         /// Runs the evaluate fitness.
         /// </summary>
         /// <param name="chromosome">The chromosome.</param>
-        private void RunEvaluateFitness(object chromosome)
+        private void RunEvaluateFitness(IChromosome chromosome)
         {
-            var c = chromosome as IChromosome;
-
             try
             {
-                c.Fitness = Fitness.Evaluate(c);
+                chromosome.Fitness = Fitness.Evaluate(chromosome);
             }
             catch (Exception ex)
             {
@@ -443,7 +441,7 @@ namespace GeneticSharp
         /// <returns>The parents.</returns>
         private IList<IChromosome> SelectParents()
         {
-            return Selection.SelectChromosomes(Population.MinSize, Population.CurrentGeneration);
+            return Selection.SelectChromosomes(Population.MinSize, Population.CurrentGeneration!);
         }
 
         /// <summary>

--- a/src/GeneticSharp.Domain/GeneticSharp.Domain.csproj
+++ b/src/GeneticSharp.Domain/GeneticSharp.Domain.csproj
@@ -5,6 +5,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>GeneticSharp.Domain</AssemblyName>
+    <Nullable>enable</Nullable>
    </PropertyGroup>
   <ItemGroup>
     <CodeAnalysisDictionary Include="CodeAnalysisDictionary.xml" />

--- a/src/GeneticSharp.Domain/IGeneticAlgorithm.cs
+++ b/src/GeneticSharp.Domain/IGeneticAlgorithm.cs
@@ -18,7 +18,7 @@ namespace GeneticSharp
         /// Gets the best chromosome.
         /// </summary>
         /// <value>The best chromosome.</value>
-        IChromosome BestChromosome { get; }
+        IChromosome? BestChromosome { get; }
 
         /// <summary>
         /// Gets the time evolving.

--- a/src/GeneticSharp.Domain/Mutations/MutationException.cs
+++ b/src/GeneticSharp.Domain/Mutations/MutationException.cs
@@ -75,7 +75,7 @@ namespace GeneticSharp
         /// Gets the mutation.
         /// </summary>
         /// <value>The mutation.</value>
-        public IMutation Mutation { get; private set; }
+        public IMutation? Mutation { get; private set; }
         #endregion
 
         #region Methods

--- a/src/GeneticSharp.Domain/Mutations/UniformMutation.cs
+++ b/src/GeneticSharp.Domain/Mutations/UniformMutation.cs
@@ -12,7 +12,7 @@ namespace GeneticSharp
     public class UniformMutation : MutationBase
     {
         #region Fields
-        private int[] m_mutableGenesIndexes;
+        private int[]? m_mutableGenesIndexes;
 
         private readonly bool m_allGenesMutable;
         #endregion

--- a/src/GeneticSharp.Domain/OperatorsStrategy/OperatorsStrategyBase.cs
+++ b/src/GeneticSharp.Domain/OperatorsStrategy/OperatorsStrategyBase.cs
@@ -36,7 +36,7 @@ namespace GeneticSharp
         /// <param name="parents">The parents.</param>
         /// <param name="firstParentIndex">the index of the first parent selected for a crossover</param>
         /// <returns>children for the current crossover if it was performed, null otherwise</returns>
-        protected static IList<IChromosome> SelectParentsAndCross(IPopulation population, ICrossover crossover,
+        protected static IList<IChromosome>? SelectParentsAndCross(IPopulation population, ICrossover crossover,
             float crossoverProbability, IList<IChromosome> parents, int firstParentIndex)
         {
             var selectedParents = parents.Skip(firstParentIndex).Take(crossover.ParentsNumber).ToList();

--- a/src/GeneticSharp.Domain/Populations/Generation.cs
+++ b/src/GeneticSharp.Domain/Populations/Generation.cs
@@ -59,7 +59,7 @@ namespace GeneticSharp
         /// Gets the best chromosome.
         /// </summary>
         /// <value>The best chromosome.</value>
-        public IChromosome BestChromosome { get; internal set; }
+        public IChromosome? BestChromosome { get; internal set; }
         #endregion
 
         #region Methods
@@ -71,7 +71,7 @@ namespace GeneticSharp
         {
             Chromosomes = Chromosomes
                 .Where(ValidateChromosome)
-                .OrderByDescending(c => c.Fitness.Value)
+                .OrderByDescending(c => c.Fitness!.Value)
                 .ToList();
 
             if (Chromosomes.Count > chromosomesNumber)

--- a/src/GeneticSharp.Domain/Populations/IPopulation.cs
+++ b/src/GeneticSharp.Domain/Populations/IPopulation.cs
@@ -34,7 +34,7 @@ namespace GeneticSharp
         /// Gets the current generation.
         /// </summary>
         /// <value>The current generation.</value>
-        Generation CurrentGeneration { get; }
+        Generation? CurrentGeneration { get; }
 
         /// <summary>
         /// Gets the total number of generations executed.
@@ -60,7 +60,7 @@ namespace GeneticSharp
         /// Gets the best chromosome.
         /// </summary>
         /// <value>The best chromosome.</value>
-        IChromosome BestChromosome { get; }
+        IChromosome? BestChromosome { get; }
 
         /// <summary>
         /// Gets or sets the generation strategy.

--- a/src/GeneticSharp.Domain/Populations/Population.cs
+++ b/src/GeneticSharp.Domain/Populations/Population.cs
@@ -11,7 +11,7 @@ namespace GeneticSharp
         /// <summary>
         /// Occurs when best chromosome changed.
         /// </summary>
-        public event EventHandler BestChromosomeChanged;
+        public event EventHandler? BestChromosomeChanged;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="GeneticSharp.Population"/> class.
@@ -59,7 +59,7 @@ namespace GeneticSharp
         /// Gets or sets the current generation.
         /// </summary>
         /// <value>The current generation.</value>
-        public Generation CurrentGeneration { get; protected set; }
+        public Generation? CurrentGeneration { get; protected set; }
 
         /// <summary>
         /// Gets or sets the total number of generations executed.
@@ -85,7 +85,7 @@ namespace GeneticSharp
         /// Gets or sets the best chromosome.
         /// </summary>
         /// <value>The best chromosome.</value>
-        public IChromosome BestChromosome { get; protected set; }
+        public IChromosome? BestChromosome { get; protected set; }
 
         /// <summary>
         /// Gets or sets the generation strategy.
@@ -144,7 +144,7 @@ namespace GeneticSharp
         /// </summary>        
         public virtual void EndCurrentGeneration()
         {
-            CurrentGeneration.End(MaxSize);
+            CurrentGeneration!.End(MaxSize);
 
             if (BestChromosome == null || BestChromosome.CompareTo(CurrentGeneration.BestChromosome) != 0)
             {

--- a/src/GeneticSharp.Domain/Randomizations/BasicRandomization.cs
+++ b/src/GeneticSharp.Domain/Randomizations/BasicRandomization.cs
@@ -37,7 +37,7 @@ namespace GeneticSharp
         /// Returns an instance of Random which can be used freely 
         /// within the current thread. 
         /// </summary> 
-        private static Random Instance { get { return _threadRandom.Value; } }
+        private static Random Instance { get { return _threadRandom.Value!; } }
 
         /// <summary>
         /// Resets the pseudorandom number generator (System.Random) initial seed.

--- a/src/GeneticSharp.Domain/Randomizations/FastRandomRandomization.cs
+++ b/src/GeneticSharp.Domain/Randomizations/FastRandomRandomization.cs
@@ -36,7 +36,7 @@ namespace GeneticSharp
         /// Returns an instance of Random which can be used freely 
         /// within the current thread. 
         /// </summary> 
-        private static FastRandom Instance { get { return _threadRandom.Value; } }
+        private static FastRandom Instance { get { return _threadRandom.Value!; } }
 
         /// <summary>
         /// Resets the pseudorandom number generator (SharpNeatLib.Maths.FastRandom) initial seed.

--- a/src/GeneticSharp.Domain/Reinsertions/ReinsertionException.cs
+++ b/src/GeneticSharp.Domain/Reinsertions/ReinsertionException.cs
@@ -75,7 +75,7 @@ namespace GeneticSharp
         /// Gets the reinsertion.
         /// </summary>
         /// <value>The reinsertion.</value>
-        public IReinsertion Reinsertion { get; private set; }
+        public IReinsertion? Reinsertion { get; private set; }
         #endregion
 
         #region Methods

--- a/src/GeneticSharp.Domain/Selections/EliteSelection.cs
+++ b/src/GeneticSharp.Domain/Selections/EliteSelection.cs
@@ -15,7 +15,7 @@ namespace GeneticSharp
     public sealed class EliteSelection : SelectionBase
     {
         readonly int _previousGenerationChromosomesNumber;
-        List<IChromosome> _previousGenerationChromosomes;
+        List<IChromosome>? _previousGenerationChromosomes;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="GeneticSharp.EliteSelection"/> class.
@@ -47,7 +47,7 @@ namespace GeneticSharp
             if(generation.Number == 1)
                 _previousGenerationChromosomes = new List<IChromosome>();
 
-            _previousGenerationChromosomes.AddRange(generation.Chromosomes);
+            _previousGenerationChromosomes!.AddRange(generation.Chromosomes);
 
             var ordered = _previousGenerationChromosomes.OrderByDescending(c => c.Fitness);
             var result = ordered.Take(number).ToList();

--- a/src/GeneticSharp.Domain/Selections/RouletteWheelSelection.cs
+++ b/src/GeneticSharp.Domain/Selections/RouletteWheelSelection.cs
@@ -67,13 +67,13 @@ namespace GeneticSharp
         /// <param name="rouletteWheel">The roulette wheel.</param>
         protected static void CalculateCumulativePercentFitness(IList<IChromosome> chromosomes, IList<double> rouletteWheel)
         {
-            var sumFitness = chromosomes.Sum(c => c.Fitness.Value);
+            var sumFitness = chromosomes.Sum(c => c.Fitness!.Value);
 
             var cumulativePercent = 0.0;
 
             for (int i = 0; i < chromosomes.Count; i++)
             {
-                cumulativePercent += chromosomes[i].Fitness.Value / sumFitness;
+                cumulativePercent += chromosomes[i].Fitness!.Value / sumFitness;
                 rouletteWheel.Add(cumulativePercent);
             }
         }

--- a/src/GeneticSharp.Domain/Selections/SelectionException.cs
+++ b/src/GeneticSharp.Domain/Selections/SelectionException.cs
@@ -75,7 +75,7 @@ namespace GeneticSharp
         /// Gets the Selection.
         /// </summary>
         /// <value>The Selection.</value>
-        public ISelection Selection { get; private set; }
+        public ISelection? Selection { get; private set; }
         #endregion
 
         #region Methods

--- a/src/GeneticSharp.Domain/Terminations/FitnessStagnationTermination.cs
+++ b/src/GeneticSharp.Domain/Terminations/FitnessStagnationTermination.cs
@@ -52,7 +52,7 @@ namespace GeneticSharp
         /// <param name="geneticAlgorithm">The genetic algorithm.</param>
         protected override bool PerformHasReached(IGeneticAlgorithm geneticAlgorithm)
         {
-            var bestFitness = geneticAlgorithm.BestChromosome.Fitness.Value;
+            var bestFitness = geneticAlgorithm.BestChromosome!.Fitness!.Value;
 
             if (m_lastFitness == bestFitness)
             {

--- a/src/GeneticSharp.Domain/Terminations/FitnessThresholdTermination.cs
+++ b/src/GeneticSharp.Domain/Terminations/FitnessThresholdTermination.cs
@@ -47,7 +47,7 @@ namespace GeneticSharp
         /// <param name="geneticAlgorithm">The genetic algorithm.</param>
         protected override bool PerformHasReached(IGeneticAlgorithm geneticAlgorithm)
         {
-            return geneticAlgorithm.BestChromosome.Fitness >= ExpectedFitness;
+            return geneticAlgorithm.BestChromosome!.Fitness >= ExpectedFitness;
         }
         #endregion
     }

--- a/src/GeneticSharp.Extensions/AutoConfig/AutoConfigChromosome.cs
+++ b/src/GeneticSharp.Extensions/AutoConfig/AutoConfigChromosome.cs
@@ -36,7 +36,7 @@ namespace GeneticSharp.Extensions
         {
             get
             {
-                return GetGene(0).Value as ISelection;
+                return (GetGene(0).Value as ISelection)!;
             }
         }
 
@@ -50,7 +50,7 @@ namespace GeneticSharp.Extensions
         {
             get
             {
-                return GetGene(1).Value as ICrossover;
+                return (GetGene(1).Value as ICrossover)!;
             }
         }
 
@@ -64,7 +64,7 @@ namespace GeneticSharp.Extensions
         {
             get
             {
-                return GetGene(2).Value as IMutation;
+                return (GetGene(2).Value as IMutation)!;
             }
         }
         #endregion

--- a/src/GeneticSharp.Extensions/AutoConfig/AutoConfigFitness.cs
+++ b/src/GeneticSharp.Extensions/AutoConfig/AutoConfigFitness.cs
@@ -68,7 +68,7 @@ namespace GeneticSharp.Extensions
         /// <returns>The chromosome fitness.</returns>
         public double Evaluate(IChromosome chromosome)
         {
-            var autoConfigChromosome = chromosome as AutoConfigChromosome;
+            var autoConfigChromosome = (chromosome as AutoConfigChromosome)!;
             var selection = autoConfigChromosome.Selection;
             var crossover = autoConfigChromosome.Crossover;
             var mutation = autoConfigChromosome.Mutation;
@@ -89,7 +89,7 @@ namespace GeneticSharp.Extensions
                 return 0;
             }
 
-            return ga.BestChromosome.Fitness.Value;
+            return ga.BestChromosome!.Fitness!.Value;
         }
         #endregion
     }

--- a/src/GeneticSharp.Extensions/Checkers/CheckersBoard.cs
+++ b/src/GeneticSharp.Extensions/Checkers/CheckersBoard.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace GeneticSharp.Extensions
 {
@@ -57,10 +58,11 @@ namespace GeneticSharp.Extensions
         /// Gets the player two's pieces.
         /// </summary>
         public IList<CheckersPiece> PlayerTwoPieces { get; private set; }
-    
+
         /// <summary>
         /// Reset the board to initial state (player one and two with pieces in start positions).
         /// </summary>
+        [MemberNotNull(nameof(PlayerOnePieces), nameof(PlayerTwoPieces))]
         public void Reset()
         {
             // Creates the two lists of pieces por player one and two.ß
@@ -133,7 +135,7 @@ namespace GeneticSharp.Extensions
 
             // Gets the piece's actual position and movement kind.
             bool moved = false;
-            var from = GetSquare(move.Piece.CurrentSquare.ColumnIndex, move.Piece.CurrentSquare.RowIndex);
+            var from = GetSquare(move.Piece.CurrentSquare!.ColumnIndex, move.Piece.CurrentSquare.RowIndex);
             var moveKind = GetMoveKind(move);
 
             // Se the movement kind is invalid between From e To positions.
@@ -141,7 +143,7 @@ namespace GeneticSharp.Extensions
             {
                 // Moves the piece to 'To' position.
                 var to = GetSquare(move.ToSquare.ColumnIndex, move.ToSquare.RowIndex);
-                to.PutPiece(from.CurrentPiece);
+                to.PutPiece(from.CurrentPiece!);
 
                 // Geets the current indexModifier.
                 var indexModifier = to.State == CheckersSquareState.OccupiedByPlayerOne ? 1 : -1;
@@ -178,7 +180,7 @@ namespace GeneticSharp.Extensions
         {
             var kind = CheckersMoveKind.Invalid;
             var player = move.Piece.Player;
-            var currentSquareState = move.Piece.CurrentSquare.State;
+            var currentSquareState = move.Piece.CurrentSquare!.State;
 
             if (currentSquareState == CheckersSquareState.OccupiedByPlayerOne || currentSquareState == CheckersSquareState.OccupiedByPlayerTwo)
             {
@@ -219,7 +221,7 @@ namespace GeneticSharp.Extensions
             ExceptionHelper.ThrowIfNull("piece", piece);
 
             var capturableCount = 0;
-            var square = piece.CurrentSquare;
+            var square = piece.CurrentSquare!;
             var newRowIndex = square.RowIndex + (2 * GetIndexModifier(piece.Player));
 
             if (IsValidIndex(newRowIndex))
@@ -252,7 +254,7 @@ namespace GeneticSharp.Extensions
             ExceptionHelper.ThrowIfNull("piece", piece);
 
             var capturedCount = 0;
-            var square = piece.CurrentSquare;
+            var square = piece.CurrentSquare!;
 
             var indexModifier = GetIndexModifier(piece.Player);
             var enemyPieceRowIndex = square.RowIndex + indexModifier;

--- a/src/GeneticSharp.Extensions/Checkers/CheckersChromosome.cs
+++ b/src/GeneticSharp.Extensions/Checkers/CheckersChromosome.cs
@@ -25,7 +25,7 @@ namespace GeneticSharp.Extensions
 
             for (int i = 0; i < movesAhead; i++)
             {
-                Moves.Add(null);
+                Moves.Add(null!); // Replaced in GenerateGene
                 ReplaceGene(i, GenerateGene(i));
             }
         }
@@ -51,7 +51,7 @@ namespace GeneticSharp.Extensions
             from.PutPiece(new CheckersPiece(CheckersPlayer.PlayerOne));
 
             var to = FindPlayableSquare();
-            var move = new CheckersMove(from.CurrentPiece, to);
+            var move = new CheckersMove(from.CurrentPiece!, to);
 
             Moves[geneIndex] = move;
 
@@ -74,7 +74,7 @@ namespace GeneticSharp.Extensions
         public override IChromosome Clone()
         {
             var clone = base.Clone() as CheckersChromosome;
-            clone.Moves = Moves;
+            clone!.Moves = Moves;
 
             return clone;
         }

--- a/src/GeneticSharp.Extensions/Checkers/CheckersFitness.cs
+++ b/src/GeneticSharp.Extensions/Checkers/CheckersFitness.cs
@@ -36,7 +36,7 @@ namespace GeneticSharp.Extensions
         public double Evaluate(IChromosome chromosome)
         {
             double fitness = 0;
-            var c = chromosome as CheckersChromosome;
+            var c = (chromosome as CheckersChromosome)!;
             double movesAhead = c.Moves.Count;
 
             var nextMovementFitness = EvaluateMove(c.Moves.First());

--- a/src/GeneticSharp.Extensions/Checkers/CheckersPiece.cs
+++ b/src/GeneticSharp.Extensions/Checkers/CheckersPiece.cs
@@ -6,7 +6,7 @@ namespace GeneticSharp.Extensions
     public class CheckersPiece
     {
         #region Fields
-        private CheckersSquare m_currentSquare;
+        private CheckersSquare? m_currentSquare;
         #endregion
 
         #region Contructors
@@ -29,7 +29,7 @@ namespace GeneticSharp.Extensions
         /// <summary>
         /// Gets or sets the current square.
         /// </summary>
-        public CheckersSquare CurrentSquare
+        public CheckersSquare? CurrentSquare
         {
             get
             {

--- a/src/GeneticSharp.Extensions/Checkers/CheckersSquare.cs
+++ b/src/GeneticSharp.Extensions/Checkers/CheckersSquare.cs
@@ -74,7 +74,7 @@ namespace GeneticSharp.Extensions
         /// Gets the current piece.
         /// </summary>
         /// <value>The current piece.</value>
-        public CheckersPiece CurrentPiece { get; private set; }
+        public CheckersPiece? CurrentPiece { get; private set; }
         #endregion
 
         #region Methods
@@ -141,7 +141,7 @@ namespace GeneticSharp.Extensions
         /// <returns>
         ///   <c>true</c> if the specified <see cref="System.Object" /> is equal to this instance; otherwise, <c>false</c>.
         /// </returns>
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             var other = obj as CheckersSquare;
 

--- a/src/GeneticSharp.Extensions/Drawing/BitmapChromosome.cs
+++ b/src/GeneticSharp.Extensions/Drawing/BitmapChromosome.cs
@@ -104,7 +104,7 @@ namespace GeneticSharp.Extensions
             {
                 for (int y = 0; y < Height; y++)
                 {
-                    result.SetPixel(x, y, (Color)GetGene(geneIndex++).Value);
+                    result.SetPixel(x, y, (Color)GetGene(geneIndex++).Value!);
                 }
             }
 

--- a/src/GeneticSharp.Extensions/Drawing/BitmapEqualityFitness.cs
+++ b/src/GeneticSharp.Extensions/Drawing/BitmapEqualityFitness.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Drawing;
 
 namespace GeneticSharp.Extensions
@@ -10,7 +11,7 @@ namespace GeneticSharp.Extensions
     public class BitmapEqualityFitness : IFitness
     {
         #region Fields
-        private IList<Color> m_targetBitmapPixels;
+        private IList<Color>? m_targetBitmapPixels;
         private int m_pixelsCount;
         #endregion
 
@@ -56,6 +57,7 @@ namespace GeneticSharp.Extensions
         /// Initializes the specified target bitmap.
         /// </summary>
         /// <param name="targetBitmap">The target bitmap.</param>
+        [MemberNotNull(nameof(m_targetBitmapPixels))]
         public void Initialize(Bitmap targetBitmap)
         {
             BitmapWidth = targetBitmap.Width;
@@ -76,8 +78,8 @@ namespace GeneticSharp.Extensions
 
             for (int i = 0; i < m_pixelsCount; i++)
             {
-                var targetPixel = m_targetBitmapPixels[i];
-                var chromosomePixel = (Color)chromosome.GetGene(i).Value;
+                var targetPixel = m_targetBitmapPixels![i];
+                var chromosomePixel = (Color)chromosome.GetGene(i).Value!;
 
                 fitness -= Math.Abs(targetPixel.R - chromosomePixel.R);
                 fitness -= Math.Abs(targetPixel.G - chromosomePixel.G);

--- a/src/GeneticSharp.Extensions/GeneticSharp.Extensions.csproj
+++ b/src/GeneticSharp.Extensions/GeneticSharp.Extensions.csproj
@@ -10,6 +10,7 @@
     <AssemblyCopyright>Diego Giacomelli, http://diegogiacomelli.com.br</AssemblyCopyright>
     <AssemblyTrademark></AssemblyTrademark>
     <AssemblyCulture></AssemblyCulture>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <!-- NuGet Package -->

--- a/src/GeneticSharp.Extensions/Ghostwriter/GhostwriterChromosome.cs
+++ b/src/GeneticSharp.Extensions/Ghostwriter/GhostwriterChromosome.cs
@@ -56,7 +56,7 @@ namespace GeneticSharp.Extensions
         /// <returns>The text.</returns>
         public string BuildText()
         {
-            return string.Join(" ", GetGenes().Select(g => g.Value.ToString()).ToArray());
+            return string.Join(" ", GetGenes().Select(g => g.Value!.ToString()).ToArray());
         }
         #endregion
     }

--- a/src/GeneticSharp.Extensions/Ghostwriter/GhostwriterFitness.cs
+++ b/src/GeneticSharp.Extensions/Ghostwriter/GhostwriterFitness.cs
@@ -32,7 +32,7 @@ namespace GeneticSharp.Extensions
         public double Evaluate(IChromosome chromosome)
         {
             var c = chromosome as GhostwriterChromosome;
-            var text = c.BuildText();
+            var text = c!.BuildText();
 
             return m_evaluateFunc(text);
         }

--- a/src/GeneticSharp.Extensions/Mathematic/EqualityFitness.cs
+++ b/src/GeneticSharp.Extensions/Mathematic/EqualityFitness.cs
@@ -17,10 +17,10 @@ namespace GeneticSharp.Extensions
         public static int GetEquationResult(EquationChromosome equalityChromosome)
         {
             var genes = equalityChromosome.GetGenes();
-            var a = (int)genes[0].Value;
-            var b = (int)genes[1].Value;
-            var c = (int)genes[2].Value;
-            var d = (int)genes[3].Value;
+            var a = (int)genes[0].Value!;
+            var b = (int)genes[1].Value!;
+            var c = (int)genes[2].Value!;
+            var d = (int)genes[3].Value!;
 
             return a + (2 * b) + (3 * c) + (4 * d);
         }
@@ -35,7 +35,7 @@ namespace GeneticSharp.Extensions
             // a + 2b + 3c + 4d = 30
             var equalityChromosome = chromosome as EquationChromosome;
 
-            var fitness = Math.Abs(GetEquationResult(equalityChromosome) - 30);
+            var fitness = Math.Abs(GetEquationResult(equalityChromosome!) - 30);
 
             return fitness * -1;
         }

--- a/src/GeneticSharp.Extensions/Mathematic/EquationSolverFitness.cs
+++ b/src/GeneticSharp.Extensions/Mathematic/EquationSolverFitness.cs
@@ -35,7 +35,7 @@ namespace GeneticSharp.Extensions
         {
             var equalityChromosome = chromosome as EquationChromosome;
 
-            var fitness = Math.Abs(m_getEquationResult(equalityChromosome.GetGenes()) - m_expectedResult);
+            var fitness = Math.Abs(m_getEquationResult(equalityChromosome!.GetGenes()) - m_expectedResult);
 
             return fitness * -1;
         }

--- a/src/GeneticSharp.Extensions/Mathematic/FunctionBuilderChromosome.cs
+++ b/src/GeneticSharp.Extensions/Mathematic/FunctionBuilderChromosome.cs
@@ -82,7 +82,7 @@ namespace GeneticSharp.Extensions
 
             foreach (var g in GetGenes())
             {
-                var op = g.Value.ToString();
+                var op = g.Value!.ToString();
 
                 if (!string.IsNullOrEmpty(op))
                 {

--- a/src/GeneticSharp.Extensions/Mathematic/FunctionBuilderFitness.cs
+++ b/src/GeneticSharp.Extensions/Mathematic/FunctionBuilderFitness.cs
@@ -44,7 +44,7 @@ namespace GeneticSharp.Extensions
         /// <returns>The fitness of the chromosome.</returns>
         public double Evaluate(IChromosome chromosome)
         {
-            var c = chromosome as FunctionBuilderChromosome;
+            var c = (chromosome as FunctionBuilderChromosome)!;
             var function = c.BuildFunction();
             var fitness = 0.0;
 

--- a/src/GeneticSharp.Extensions/Sudoku/SudokuCellsChromosome.cs
+++ b/src/GeneticSharp.Extensions/Sudoku/SudokuCellsChromosome.cs
@@ -18,14 +18,14 @@ namespace GeneticSharp.Extensions
         /// Basic constructor with target sudoku to solve
         /// </summary>
         /// <param name="targetSudokuBoard">the target sudoku to solve</param>
-        public SudokuCellsChromosome(SudokuBoard targetSudokuBoard) : this( targetSudokuBoard, null) {}
+        public SudokuCellsChromosome(SudokuBoard? targetSudokuBoard) : this( targetSudokuBoard, null) {}
 
         /// <summary>
         /// Constructor with additional precomputed domains for faster cloning
         /// </summary>
         /// <param name="targetSudokuBoard">the target sudoku to solve</param>
         /// <param name="extendedMask">The cell domains after initial constraint propagation</param>
-        public SudokuCellsChromosome(SudokuBoard targetSudokuBoard, Dictionary<int, List<int>> extendedMask) : base(targetSudokuBoard, extendedMask, 81)
+        public SudokuCellsChromosome(SudokuBoard? targetSudokuBoard, Dictionary<int, List<int>>? extendedMask) : base(targetSudokuBoard, extendedMask, 81)
 	    {
 	    }
 
@@ -54,7 +54,7 @@ namespace GeneticSharp.Extensions
         /// <returns>A Sudoku board built from the 81 genes</returns>
         public override IList<SudokuBoard> GetSudokus()
         {
-            var sudoku = new SudokuBoard(GetGenes().Select(g => (int)g.Value));
+            var sudoku = new SudokuBoard(GetGenes().Select(g => (int)g.Value!));
             return new List<SudokuBoard>(new[] { sudoku });
         }
     }

--- a/src/GeneticSharp.Extensions/Sudoku/SudokuChromosomeBase.cs
+++ b/src/GeneticSharp.Extensions/Sudoku/SudokuChromosomeBase.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace GeneticSharp.Extensions
@@ -12,12 +13,12 @@ namespace GeneticSharp.Extensions
         /// <summary>
         /// The target sudoku board to solve
         /// </summary>
-        private readonly SudokuBoard _targetSudokuBoard;
+        private readonly SudokuBoard? _targetSudokuBoard;
 
         /// <summary>
         /// The cell domains updated from the initial mask for the board to solve
         /// </summary>
-        private  Dictionary<int, List<int>> _extendedMask;
+        private  Dictionary<int, List<int>>? _extendedMask;
 
         /// <summary>
         /// Constructor that accepts an additional extended mask for quick cloning
@@ -25,7 +26,7 @@ namespace GeneticSharp.Extensions
         /// <param name="targetSudokuBoard">the target sudoku to solve</param>
         /// <param name="extendedMask">The cell domains after initial constraint propagation</param>
         /// <param name="length">The number of genes for the sudoku chromosome</param>
-        protected SudokuChromosomeBase(SudokuBoard targetSudokuBoard, Dictionary<int, List<int>> extendedMask, int length) : base(length)
+        protected SudokuChromosomeBase(SudokuBoard? targetSudokuBoard, Dictionary<int, List<int>>? extendedMask, int length) : base(length)
         {
             _targetSudokuBoard = targetSudokuBoard;
             _extendedMask = extendedMask;
@@ -36,7 +37,7 @@ namespace GeneticSharp.Extensions
         /// <summary>
         /// The target sudoku board to solve
         /// </summary>
-        public SudokuBoard TargetSudokuBoard => _targetSudokuBoard;
+        public SudokuBoard? TargetSudokuBoard => _targetSudokuBoard;
 
         /// <summary>
         /// The cell domains updated from the initial mask for the board to solve
@@ -52,6 +53,7 @@ namespace GeneticSharp.Extensions
             }
         }
 
+        [MemberNotNull(nameof(_extendedMask))]
         private void BuildExtenedMask()
         {
             // We generate 1 to 9 figures for convenience
@@ -61,7 +63,7 @@ namespace GeneticSharp.Extensions
             {
                 //If target sudoku mask is provided, we generate an inverted mask with forbidden values by propagating rows, columns and boxes constraints
                 var forbiddenMask = new Dictionary<int, List<int>>();
-                List<int> targetList = null;
+                List<int>? targetList = null;
                 for (var index = 0; index < _targetSudokuBoard.Cells.Count; index++)
                 {
                     var targetCell = _targetSudokuBoard.Cells[index];

--- a/src/GeneticSharp.Extensions/Sudoku/SudokuPermutationsChromosome.cs
+++ b/src/GeneticSharp.Extensions/Sudoku/SudokuPermutationsChromosome.cs
@@ -14,7 +14,7 @@ namespace GeneticSharp.Extensions
         /// <summary>
         /// The list of row permutations accounting for the mask
         /// </summary>
-        private  IList<IList<IList<int>>> _targetRowsPermutations;
+        private  IList<IList<IList<int>>>? _targetRowsPermutations;
 
 
         /// <summary>
@@ -26,19 +26,19 @@ namespace GeneticSharp.Extensions
         /// Constructor with a mask sudoku to solve, assuming a length of 9 genes
         /// </summary>
         /// <param name="targetSudokuBoard">the target sudoku to solve</param>
-        public SudokuPermutationsChromosome(SudokuBoard targetSudokuBoard) : this(targetSudokuBoard, 9) {}
+        public SudokuPermutationsChromosome(SudokuBoard? targetSudokuBoard) : this(targetSudokuBoard, 9) {}
 
         /// <summary>
         /// Constructor with a mask and a number of genes
         /// </summary>
         /// <param name="targetSudokuBoard">the target sudoku to solve</param>
         /// <param name="length">the number of genes</param>
-        public SudokuPermutationsChromosome(SudokuBoard targetSudokuBoard, int length) : this(targetSudokuBoard, null, length) {}    
+        public SudokuPermutationsChromosome(SudokuBoard? targetSudokuBoard, int length) : this(targetSudokuBoard, null, length) {}    
 
         /// <param name="targetSudokuBoard">the target sudoku to solve</param>
         /// <param name="extendedMask">The cell domains after initial constraint propagation</param>
         /// <param name="length">The number of genes for the sudoku chromosome</param>
-        public SudokuPermutationsChromosome(SudokuBoard targetSudokuBoard, Dictionary<int, List<int>> extendedMask, int length) : base(targetSudokuBoard, extendedMask, length) { }
+        public SudokuPermutationsChromosome(SudokuBoard? targetSudokuBoard, Dictionary<int, List<int>>? extendedMask, int length) : base(targetSudokuBoard, extendedMask, length) { }
 
 
         /// <summary>
@@ -117,7 +117,7 @@ namespace GeneticSharp.Extensions
         /// <returns>the index of the permutation to apply</returns>
         protected virtual int GetPermutationIndex(int rowIndex)
         {
-            return (int)GetGene(rowIndex).Value;
+            return (int)GetGene(rowIndex).Value!;
         }
 
 

--- a/src/GeneticSharp.Extensions/Sudoku/SudokuRandomPermutationsChromosome.cs
+++ b/src/GeneticSharp.Extensions/Sudoku/SudokuRandomPermutationsChromosome.cs
@@ -43,7 +43,7 @@ namespace GeneticSharp.Extensions
         /// <param name="targetSudokuBoard">the target sudoku to solve</param>
         /// <param name="nbPermutations">the number of permutation genes per row</param>
         /// <param name="nbSudokus">the number of Sudokus generated for evaluation</param>
-        public SudokuRandomPermutationsChromosome(SudokuBoard targetSudokuBoard, Dictionary<int, List<int>> extendedMask, int nbPermutations, int nbSudokus) : base(targetSudokuBoard, extendedMask, 9 * nbPermutations)
+        public SudokuRandomPermutationsChromosome(SudokuBoard? targetSudokuBoard, Dictionary<int, List<int>>? extendedMask, int nbPermutations, int nbSudokus) : base(targetSudokuBoard, extendedMask, 9 * nbPermutations)
         {
             _nbPermutations = nbPermutations;
             _nbSudokus = nbSudokus;
@@ -91,7 +91,7 @@ namespace GeneticSharp.Extensions
             var rnd = RandomizationProvider.Current;
             var switchIdx = rnd.GetInt(0, _nbPermutations);
             var permGeneIdx = switchIdx * 9 + rowIndex;
-            return (int)GetGene(permGeneIdx).Value;
+            return (int)GetGene(permGeneIdx).Value!;
         }
 
         public override IChromosome CreateNew()

--- a/src/GeneticSharp.Extensions/Tsp/TspChromosome.cs
+++ b/src/GeneticSharp.Extensions/Tsp/TspChromosome.cs
@@ -67,7 +67,7 @@ namespace GeneticSharp.Extensions
         public override IChromosome Clone()
         {
             var clone = base.Clone() as TspChromosome;
-            clone.Distance = Distance;
+            clone!.Distance = Distance;
 
             return clone;
         }

--- a/src/GeneticSharp.Infrastructure.Framework/GeneticSharp.Infrastructure.Framework.csproj
+++ b/src/GeneticSharp.Infrastructure.Framework/GeneticSharp.Infrastructure.Framework.csproj
@@ -5,5 +5,6 @@
     <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>GeneticSharp.Infrastructure.Framework</AssemblyName>
     <PackageId>GeneticSharp.Infrastructure.Framework</PackageId>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 </Project>

--- a/src/GeneticSharp.Infrastructure.Framework/Reflection/TypeHelper.cs
+++ b/src/GeneticSharp.Infrastructure.Framework/Reflection/TypeHelper.cs
@@ -22,7 +22,7 @@ namespace GeneticSharp
             var assemblies = AppDomain.CurrentDomain.GetAssemblies();
 
             var selectedAssemblies = assemblies.Where(
-                a => a.FullName.StartsWith("GeneticSharp.", StringComparison.OrdinalIgnoreCase));
+                a => a.FullName!.StartsWith("GeneticSharp.", StringComparison.OrdinalIgnoreCase));
 
             var types = selectedAssemblies.SelectMany(a => a.GetTypes())
                     .Where(t => t.GetInterfaces().Any(i => i == interfaceType) && !t.IsAbstract)
@@ -57,7 +57,7 @@ namespace GeneticSharp
 
             try
             {
-                return (TInterface)Activator.CreateInstance(crossoverType, constructorArgs);
+                return (TInterface)Activator.CreateInstance(crossoverType, constructorArgs)!;
             }
             catch (MissingMethodException ex)
             {
@@ -95,7 +95,7 @@ namespace GeneticSharp
                 throw new InvalidOperationException("The member '{0}' has no DisplayNameAttribute.".With(member.Name));
             }
 
-            return attribute as DisplayNameAttribute;
+            return (attribute as DisplayNameAttribute)!;
         }        
     }
 }

--- a/src/GeneticSharp.Infrastructure.Framework/Threading/ParallelTaskExecutor.cs
+++ b/src/GeneticSharp.Infrastructure.Framework/Threading/ParallelTaskExecutor.cs
@@ -34,7 +34,7 @@ namespace GeneticSharp
         /// <summary>
         /// Gets or sets the cancellation token source.
         /// </summary>
-        protected CancellationTokenSource CancellationTokenSource { get; set; }
+        protected CancellationTokenSource? CancellationTokenSource { get; set; }
 
         /// <summary>
         /// Starts the tasks execution.


### PR DESCRIPTION
This enables [nullable reference types](https://learn.microsoft.com/en-us/dotnet/csharp/nullable-references) for the 3 core projects (Infrastructure.Framework, Domain, Extensions).

I tried enabling it solution-wide but that resulted in another >300 warnings that I didn't want to go through, and fixing them in the test projects didn't seem worthwhile.

I ended up using the null-forgiving operator a lot here, often for cases like nullable elements inside a class where they'd first be checked for any nulls in one place, then accessed in another method that correctly assumed they weren't null. Or cases where `obj as Type` was used and the type was guaranteed (arguably a cast is better here, but I wanted to change as little as possible). I think a good amount of this kind of thing can be fixed with some restructuring that I might attempt later, but it seemed nice to get this in first, if you'll accept it.