### PR TITLE
Add an IFitness Variant to Compute Fitness for a Collection of Chromosomes on a Vector Processor

### DIFF
--- a/src/GeneticSharp.Domain/Fitnesses/FuncFitness.cs
+++ b/src/GeneticSharp.Domain/Fitnesses/FuncFitness.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace GeneticSharp
 {
@@ -30,4 +31,29 @@ namespace GeneticSharp
         }
         #endregion
     }
+
+    public class VectorFuncFitness : VectorFitness
+    {
+        private readonly Func<IList<IChromosome>, double[]> m_func;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:GeneticSharp.Domain.Fitnesses.VectorFuncFitness"/> class.
+        /// </summary>
+        /// <param name="func">The fitness evaluation Func.</param>
+        public VectorFuncFitness(Func<IList<IChromosome>, double[]> func)
+        {
+            ExceptionHelper.ThrowIfNull("func", func);
+            m_func = func;
+        }
+
+        /// <summary>
+        /// Evaluates the specified chromosomes and returns their fitness values as a vector.
+        /// </summary>
+        /// <param name="chromosomes">The chromosomes to be evaluated.</param>
+        /// <returns>A vector of fitness values corresponding to the input chromosomes.</returns>
+        public override double[] Evaluate(IList<IChromosome> chromosomes)
+        {
+            return m_func(chromosomes);
+        }
+	}
 }

--- a/src/GeneticSharp.Domain/Fitnesses/VectorFitness.cs
+++ b/src/GeneticSharp.Domain/Fitnesses/VectorFitness.cs
@@ -1,0 +1,32 @@
+﻿using System.Collections.Generic;
+
+namespace GeneticSharp
+{
+	/// <summary>
+	/// Defines an interface for a vector fitness function.  <see cref="GeneticSharp.Domain.Fitnesses.IFitness"/>, for discussion of a scalar fitness function.
+	/// <remarks>
+	/// A vector fitness function extends the notion of a scalar fitness function to express the vector result of a fitness function run in parallel on a vector-processor
+	/// device such as a GPU.  Given a set of chromosomes, the vector fitness function evaluates the chromosomes in the set on a logical vector device, and returns a vector of fitness values.
+	/// This approach differs from and offers convenience relative to the scalar fitness function executed in parallel with <see cref="GeneticSharp.Infrastructure.Framework.Threading.ParallelTaskExecutor"/>,
+	/// as VectorFitness delegates the parallel scoring of the chromosomes to the vector device and its substantial parallelism, rather than using a CPU thread per chromosome.
+	/// Applications <em>must</em> use instances of this class with <see cref="GeneticSharp.Infrastructure.Framework.Threading.LinearTaskExecutor"/>.
+	/// <see href="http://en.wikipedia.org/wiki/Fitness_function">Wikipedia</see>
+	/// </remarks>
+	/// </summary>
+	public abstract class VectorFitness : IFitness
+	{
+		public double Evaluate(IChromosome chromosome)
+		{
+			// This method is not used in VectorFitness, but is required by the IFitness interface.
+			// It is provided here to satisfy the interface contract, but should not be called.
+			throw new System.NotSupportedException("IVectorFitness does not support single chromosome evaluation. Use Evaluate(IList<IChromosome>) or IFitness.Evaluate(IChromosome) instead.");
+		}
+
+		/// <summary>
+		/// Evaluates the specified chromosomes and returns their fitness values as a vector.
+		/// </summary>
+		/// <param name="chromosomes">The chromosomes to be evaluated.</param>
+		/// <returns>A vector of fitness values corresponding to the input chromosomes.  The indexes of the fitness values match the indexes of the chromosomes in the list.</returns>
+		public abstract double[] Evaluate(IList<IChromosome> chromosomes);
+	}
+}

--- a/src/GeneticSharp.Runner.ConsoleApp/GeneticSharp.Runner.ConsoleApp.csproj
+++ b/src/GeneticSharp.Runner.ConsoleApp/GeneticSharp.Runner.ConsoleApp.csproj
@@ -2,10 +2,10 @@
   <Import Project="..\msbuilds\GeneticSharp.dotnet-core.targets" />
   <Import Project="..\msbuilds\GeneticSharp.common.targets" />
   <Import Project="..\msbuilds\GeneticSharp.app.targets" />
-  
+
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <OutputType>Exe</OutputType>    
+    <OutputType>Exe</OutputType>
     <RuntimeIdentifiers>win7-x86;osx-x64;linux-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="NCalc.NetCore" Version="1.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2-beta2" />
-    <PackageReference Include="Magick.NET-Q16-AnyCPU" Version="12.1.0" />
+    <PackageReference Include="Magick.NET-Q16-AnyCPU" Version="14.6.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -21,7 +21,7 @@
     <ProjectReference Include="..\GeneticSharp.Extensions\GeneticSharp.Extensions.csproj" />
     <ProjectReference Include="..\GeneticSharp.Infrastructure.Framework\GeneticSharp.Infrastructure.Framework.csproj" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <None Include="Resources\GhostwriterQuotex.json.txt" />
   </ItemGroup>


### PR DESCRIPTION
** THIS PR IS INCOMPLETE, SPECIFICALLY IN TEST COVERAGE. **

This PR is a draft implementation of the `IVectorFitness` concept we discussed in email.  It has come out much like what I suggested, except the vector extension uses an abstract implementation of `IFitness` and a runtime type check instead of altering `IFitness`, for backward compatibility.

It is agnostic wrt vector processing (GPU) libraries the user may use.

I'm looking for questions & Feedback on this approach before I extend the tests.

One question: Do I need to worry about consumers of `IFitness` other than `GeneticAlgorithm` that might expect a `VectorFitness` to work polymorphically?

This also includes the change for issue #135.  Thanks!
