### PR TITLE
Start With a Seed Population

### DIFF
--- a/src/GeneticSharp.Domain/Chromosomes/ChromosomeBase.cs
+++ b/src/GeneticSharp.Domain/Chromosomes/ChromosomeBase.cs
@@ -304,7 +304,7 @@ namespace GeneticSharp
         /// </code>
         /// </remarks>
         /// </summary>        
-        protected virtual void CreateGenes()
+        public virtual void CreateGenes()
         {
             for (int i = 0; i < Length; i++)
             {

--- a/src/GeneticSharp.Domain/Chromosomes/IChromosome.cs
+++ b/src/GeneticSharp.Domain/Chromosomes/IChromosome.cs
@@ -83,6 +83,8 @@ namespace GeneticSharp
         /// </summary>
         /// <returns>The chromosome clone.</returns>
         IChromosome Clone();
+
+        void CreateGenes();
         #endregion
     }
 }

--- a/src/GeneticSharp.Domain/GeneticSharp.Domain.csproj
+++ b/src/GeneticSharp.Domain/GeneticSharp.Domain.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\msbuilds\GeneticSharp.common.targets" />
   
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>GeneticSharp.Domain</AssemblyName>
    </PropertyGroup>
   <ItemGroup>

--- a/src/GeneticSharp.Domain/Populations/Population.cs
+++ b/src/GeneticSharp.Domain/Populations/Population.cs
@@ -12,7 +12,7 @@ namespace GeneticSharp
         /// Occurs when best chromosome changed.
         /// </summary>
         public event EventHandler BestChromosomeChanged;
-
+        private readonly IEnumerable<IChromosome> _seedPopulation = null;
         /// <summary>
         /// Initializes a new instance of the <see cref="GeneticSharp.Population"/> class.
         /// </summary>
@@ -40,7 +40,28 @@ namespace GeneticSharp
             Generations = new List<Generation>();
             GenerationStrategy = new PerformanceGenerationStrategy(10);
         }
-        
+        public Population(int minSize, int maxSize, IList<IChromosome> seedPopulation)
+        {
+            if (minSize < 2)
+            {
+                throw new ArgumentOutOfRangeException(nameof(minSize), "The minimum size for a population is 2 chromosomes.");
+            }
+
+            if (maxSize < minSize)
+            {
+                throw new ArgumentOutOfRangeException(nameof(maxSize), "The maximum size for a population should be equal or greater than minimum size.");
+            }
+
+            ExceptionHelper.ThrowIfNull(nameof(seedPopulation), seedPopulation);
+
+            CreationDate = DateTime.Now;
+            MinSize = minSize;
+            MaxSize = maxSize;
+            _seedPopulation = seedPopulation;
+            AdamChromosome = seedPopulation[0];
+            Generations = new List<Generation>();
+            GenerationStrategy = new PerformanceGenerationStrategy(10);
+        }
         /// <summary>
         /// Gets or sets the creation date.
         /// </summary>
@@ -107,10 +128,14 @@ namespace GeneticSharp
             GenerationsNumber = 0;
 
             var chromosomes = new List<IChromosome>();
-
-            for (int i = 0; i < MinSize; i++)
+            if (_seedPopulation != null)
+            {
+                chromosomes.AddRange(_seedPopulation);
+            }
+            for (int i = chromosomes.Count; i < MinSize; i++)
             {
                 var c = AdamChromosome.CreateNew();
+                c.CreateGenes();
 
                 if (c == null)
                 {

--- a/src/GeneticSharp.Infrastructure.Framework/GeneticSharp.Infrastructure.Framework.csproj
+++ b/src/GeneticSharp.Infrastructure.Framework/GeneticSharp.Infrastructure.Framework.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\msbuilds\GeneticSharp.dotnet-core.targets" />
   <Import Project="..\msbuilds\GeneticSharp.common.targets" />
   <PropertyGroup> 
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>GeneticSharp.Infrastructure.Framework</AssemblyName>
     <PackageId>GeneticSharp.Infrastructure.Framework</PackageId>
   </PropertyGroup>


### PR DESCRIPTION
Rather than starting with a random population, this allows you to start with a population of existing chromosomes.  When initializing Population, you would supply a small population to jump start your algorithm.

This is useful for the following scenarios:

- Resuming a previous session
- Fine-tuning a selection of chromosomes
- If finding viable chromosomes on a random basis is costly

This includes updating to .Net 8.