### PR TITLE
Added IAsyncFitness and IMutation.MinChromosomeLength

### DIFF
--- a/src/GeneticSharp.Domain.UnitTests/GeneticAlgorithmTest.cs
+++ b/src/GeneticSharp.Domain.UnitTests/GeneticAlgorithmTest.cs
@@ -683,6 +683,103 @@ namespace GeneticSharp.Domain.UnitTests
         }
 
         [Test()]
+        public void Start_AsyncFitness_Optimization()
+        {
+            var selection = new EliteSelection();
+            var crossover = new OnePointCrossover(2);
+            var mutation = new UniformMutation();
+            var chromosome = new ChromosomeStub();
+            var target = new GeneticAlgorithm(new Population(50, 50, chromosome),
+                new AsyncFitnessStub() { SupportsParallel = false }, selection, crossover, mutation);
+
+            target.Population.GenerationStrategy = new TrackingGenerationStrategy();
+            target.Termination = new GenerationNumberTermination(25);
+
+            target.Start();
+
+            Assert.AreEqual(GeneticAlgorithmState.TerminationReached, target.State);
+            Assert.IsFalse(target.IsRunning);
+            Assert.AreEqual(25, target.Population.Generations.Count);
+
+            var lastFitness = 0.0;
+
+            foreach (var g in target.Population.Generations)
+            {
+                Assert.GreaterOrEqual(g.BestChromosome.Fitness.Value, lastFitness);
+                lastFitness = g.BestChromosome.Fitness.Value;
+            }
+
+            Assert.GreaterOrEqual(lastFitness, 0.8);
+        }
+
+        [Test()]
+        public void Start_AsyncFitnessParallel_Optimization()
+        {
+            var taskExecutor = new ParallelTaskExecutor();
+            taskExecutor.MinThreads = 100;
+            taskExecutor.MaxThreads = 100;
+
+            var selection = new EliteSelection();
+            var crossover = new OnePointCrossover(1);
+            var mutation = new UniformMutation();
+            var chromosome = new ChromosomeStub();
+
+            FlowAssert.IsAtLeastOneAttemptOk(20, () =>
+            {
+                var target = new GeneticAlgorithm(new Population(100, 150, chromosome),
+                new AsyncFitnessStub() { SupportsParallel = true }, selection, crossover, mutation);
+                target.TaskExecutor = taskExecutor;
+
+                target.Start();
+
+                Assert.AreEqual(GeneticAlgorithmState.TerminationReached, target.State);
+                Assert.IsFalse(target.IsRunning);
+                Assert.IsNotNull(target.Population.BestChromosome);
+                Assert.IsTrue(target.Population.BestChromosome.Fitness >= 0.9, $"Fitness should be >= 0.9, but is {target.Population.BestChromosome.Fitness}");
+            });
+        }
+
+        [Test()]
+        public void Start_AsyncFitnessCancellation_OperationCanceled()
+        {
+            var cts = new CancellationTokenSource();
+            var taskExecutor = new LinearTaskExecutor(cts.Token);
+
+            var selection = new EliteSelection();
+            var crossover = new OnePointCrossover(2);
+            var mutation = new UniformMutation();
+            var chromosome = new ChromosomeStub();
+            var target = new GeneticAlgorithm(new Population(50, 50, chromosome),
+                new AsyncFitnessStub() { SupportsParallel = true, ParallelSleep = 5000 }, selection, crossover, mutation);
+            target.TaskExecutor = taskExecutor;
+            target.Termination = new GenerationNumberTermination(25);
+
+            cts.CancelAfter(100);
+
+            Assert.Catch<FitnessException>(() =>
+            {
+                target.Start();
+            });
+        }
+
+        [Test()]
+        public void Start_AsyncFitnessEvaluationFailed_FitnessException()
+        {
+            var selection = new RouletteWheelSelection();
+            var crossover = new OnePointCrossover(1);
+            var mutation = new UniformMutation();
+            var chromosome = new ChromosomeStub();
+            var fitness = new AsyncFuncFitness((c, ct) => throw new Exception("TEST"));
+
+            var target = new GeneticAlgorithm(new Population(100, 150, chromosome), fitness, selection, crossover, mutation);
+
+            Assert.Catch<FitnessException>(target.Start);
+
+            Assert.IsFalse(target.IsRunning);
+            Assert.AreEqual(GeneticAlgorithmState.Stopped, target.State);
+        }
+
+        [Test()]
         public void Stop_NotStarted_Exception()
         {
             var selection = new EliteSelection();

--- a/src/GeneticSharp.Domain.UnitTests/GeneticAlgorithmTest.cs
+++ b/src/GeneticSharp.Domain.UnitTests/GeneticAlgorithmTest.cs
@@ -756,7 +756,7 @@ namespace GeneticSharp.Domain.UnitTests
 
             cts.CancelAfter(100);
 
-            Assert.Catch<FitnessException>(() =>
+            Assert.Catch<OperationCanceledException>(() =>
             {
                 target.Start();
             });

--- a/src/GeneticSharp.Domain.UnitTests/Mutations/MinChromosomeLengthTest.cs
+++ b/src/GeneticSharp.Domain.UnitTests/Mutations/MinChromosomeLengthTest.cs
@@ -1,0 +1,25 @@
+﻿using NUnit.Framework;
+
+namespace GeneticSharp.Domain.UnitTests.Mutations
+{
+    [TestFixture()]
+    [Category("Mutations")]
+    public class MinChromosomeLengthTest
+    {
+        [Test()]
+        public void MinChromosomeLength_SequenceMutations_Three()
+        {
+            Assert.AreEqual(3, new DisplacementMutation().MinChromosomeLength);
+            Assert.AreEqual(3, new InsertionMutation().MinChromosomeLength);
+            Assert.AreEqual(3, new PartialShuffleMutation().MinChromosomeLength);
+            Assert.AreEqual(3, new ReverseSequenceMutation().MinChromosomeLength);
+        }
+
+        [Test()]
+        public void MinChromosomeLength_NonSequenceMutations_Zero()
+        {
+            Assert.AreEqual(0, new TworsMutation().MinChromosomeLength);
+            Assert.AreEqual(0, new UniformMutation().MinChromosomeLength);
+        }
+    }
+}

--- a/src/GeneticSharp.Domain.UnitTests/Populations/AsyncFitnessStub.cs
+++ b/src/GeneticSharp.Domain.UnitTests/Populations/AsyncFitnessStub.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace GeneticSharp.Domain.UnitTests
+{
+    public class AsyncFitnessStub : IFitness, IAsyncFitness
+    {
+        public AsyncFitnessStub()
+        {
+            ParallelSleep = 500;
+        }
+
+        public bool SupportsParallel { get; set; }
+        public int ParallelSleep { get; set; }
+
+        public double Evaluate(IChromosome chromosome)
+        {
+            throw new NotSupportedException("Use EvaluateAsync instead.");
+        }
+
+        public async Task<double> EvaluateAsync(IChromosome chromosome, CancellationToken cancellationToken)
+        {
+            if (SupportsParallel)
+            {
+                await Task.Delay(ParallelSleep, cancellationToken);
+            }
+
+            var genes = chromosome.GetGenes();
+            double f = genes.Sum(g => (int)g.Value) / 20f;
+
+            if (f > 1)
+            {
+                f = 0;
+            }
+
+            return f;
+        }
+    }
+}

--- a/src/GeneticSharp.Domain/Fitnesses/AsyncFuncFitness.cs
+++ b/src/GeneticSharp.Domain/Fitnesses/AsyncFuncFitness.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace GeneticSharp
+{
+    /// <summary>
+    /// An IAsyncFitness implementation that defers the fitness evaluation to an async Func.
+    /// </summary>
+    public class AsyncFuncFitness : IFitness, IAsyncFitness
+    {
+        private readonly Func<IChromosome, CancellationToken, Task<double>> m_func;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AsyncFuncFitness"/> class.
+        /// </summary>
+        /// <param name="func">The async fitness evaluation Func.</param>
+        public AsyncFuncFitness(Func<IChromosome, CancellationToken, Task<double>> func)
+        {
+            ExceptionHelper.ThrowIfNull("func", func);
+            m_func = func;
+        }
+
+        /// <summary>
+        /// Evaluate the specified chromosome.
+        /// </summary>
+        /// <param name="chromosome">Chromosome.</param>
+        public double Evaluate(IChromosome chromosome)
+        {
+            throw new NotSupportedException("Use EvaluateAsync instead.");
+        }
+
+        /// <summary>
+        /// Evaluate the specified chromosome asynchronously.
+        /// </summary>
+        /// <param name="chromosome">Chromosome.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        public Task<double> EvaluateAsync(IChromosome chromosome, CancellationToken cancellationToken)
+        {
+            return m_func(chromosome, cancellationToken);
+        }
+    }
+}

--- a/src/GeneticSharp.Domain/Fitnesses/IAsyncFitness.cs
+++ b/src/GeneticSharp.Domain/Fitnesses/IAsyncFitness.cs
@@ -1,0 +1,19 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace GeneticSharp
+{
+    /// <summary>
+    /// Defines an interface for asynchronous fitness function.
+    /// </summary>
+    public interface IAsyncFitness
+    {
+        /// <summary>
+        /// Performs the evaluation against the specified chromosome asynchronously.
+        /// </summary>
+        /// <param name="chromosome">The chromosome to be evaluated.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>The fitness of the chromosome.</returns>
+        Task<double> EvaluateAsync(IChromosome chromosome, CancellationToken cancellationToken);
+    }
+}

--- a/src/GeneticSharp.Domain/GeneticAlgorithm.cs
+++ b/src/GeneticSharp.Domain/GeneticAlgorithm.cs
@@ -441,9 +441,13 @@ namespace GeneticSharp
             {
                 c.Fitness = await asyncFitness.EvaluateAsync(c, ct);
             }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
             catch (Exception ex)
             {
-                throw new FitnessException(Fitness, "Error executing Fitness.Evaluate for chromosome: {0}".With(ex.Message), ex);
+                throw new FitnessException(Fitness, "Error executing Fitness.EvaluateAsync for chromosome: {0}".With(ex.Message), ex);
             }
         }
 

--- a/src/GeneticSharp.Domain/GeneticAlgorithm.cs
+++ b/src/GeneticSharp.Domain/GeneticAlgorithm.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace GeneticSharp
 {
@@ -399,10 +401,7 @@ namespace GeneticSharp
                 {
                     var c = chromosomesWithoutFitness[i];
 
-                    TaskExecutor.Add(() =>
-                    {
-                        RunEvaluateFitness(c);
-                    });
+                    TaskExecutor.Add(ct => RunEvaluateFitness(c, ct));
                 }
 
                 if (!TaskExecutor.Start())
@@ -419,17 +418,28 @@ namespace GeneticSharp
             Population.CurrentGeneration.Chromosomes = Population.CurrentGeneration.Chromosomes.OrderByDescending(c => c.Fitness.Value).ToList();
         }
 
-        /// <summary>
-        /// Runs the evaluate fitness.
-        /// </summary>
-        /// <param name="chromosome">The chromosome.</param>
-        private void RunEvaluateFitness(object chromosome)
+        private ValueTask RunEvaluateFitness(IChromosome c, CancellationToken ct)
         {
-            var c = chromosome as IChromosome;
+            if (Fitness is IAsyncFitness asyncFitness)
+                return RunEvaluateFitnessAsync(c, asyncFitness, ct);
 
             try
             {
                 c.Fitness = Fitness.Evaluate(c);
+            }
+            catch (Exception ex)
+            {
+                throw new FitnessException(Fitness, "Error executing Fitness.Evaluate for chromosome: {0}".With(ex.Message), ex);
+            }
+
+            return default;
+        }
+
+        private async ValueTask RunEvaluateFitnessAsync(IChromosome c, IAsyncFitness asyncFitness, CancellationToken ct)
+        {
+            try
+            {
+                c.Fitness = await asyncFitness.EvaluateAsync(c, ct);
             }
             catch (Exception ex)
             {

--- a/src/GeneticSharp.Domain/Mutations/IMutation.cs
+++ b/src/GeneticSharp.Domain/Mutations/IMutation.cs
@@ -24,6 +24,11 @@ namespace GeneticSharp
     public interface IMutation : IChromosomeOperator
     {
         /// <summary>
+        /// Gets the minimum chromosome length required by this mutation.
+        /// </summary>
+        int MinChromosomeLength { get; }
+
+        /// <summary>
         /// Mutate the specified chromosome.
         /// </summary>
         /// <param name="chromosome">The chromosome.</param>

--- a/src/GeneticSharp.Domain/Mutations/MutationBase.cs
+++ b/src/GeneticSharp.Domain/Mutations/MutationBase.cs
@@ -10,6 +10,11 @@
         /// Gets or sets a value indicating whether the operator is ordered (if can keep the chromosome order).
         /// </summary>
         public bool IsOrdered { get; protected set; }
+
+        /// <summary>
+        /// Gets the minimum chromosome length required by this mutation.
+        /// </summary>
+        public virtual int MinChromosomeLength => 0;
         #endregion
 
         #region Methods

--- a/src/GeneticSharp.Domain/Mutations/SequenceMutationBase.cs
+++ b/src/GeneticSharp.Domain/Mutations/SequenceMutationBase.cs
@@ -44,7 +44,7 @@ namespace GeneticSharp
         {
             if (chromosome.Length < MinChromosomeLength)
             {
-                throw new MutationException(this, "A chromosome should have, at least, 3 genes. {0} has only {1} gene.".With(chromosome.GetType().Name, chromosome.Length));
+                throw new MutationException(this, "A chromosome should have, at least, {0} genes. {1} has only {2} gene.".With(MinChromosomeLength, chromosome.GetType().Name, chromosome.Length));
             }
         }
 

--- a/src/GeneticSharp.Domain/Mutations/SequenceMutationBase.cs
+++ b/src/GeneticSharp.Domain/Mutations/SequenceMutationBase.cs
@@ -8,6 +8,11 @@ namespace GeneticSharp
     /// </summary>
     public abstract class SequenceMutationBase : MutationBase
     {
+        /// <summary>
+        /// Gets the minimum chromosome length required by this mutation.
+        /// </summary>
+        public override int MinChromosomeLength => 3;
+
         #region Methods
         /// <summary>
         /// Mutate the specified chromosome.
@@ -37,7 +42,7 @@ namespace GeneticSharp
         /// <param name="chromosome">The chromosome.</param>
         protected virtual void ValidateLength(IChromosome chromosome)
         {
-            if (chromosome.Length < 3)
+            if (chromosome.Length < MinChromosomeLength)
             {
                 throw new MutationException(this, "A chromosome should have, at least, 3 genes. {0} has only {1} gene.".With(chromosome.GetType().Name, chromosome.Length));
             }

--- a/src/GeneticSharp.Infrastructure.Framework.UnitTests/Threading/StubTaskExecutor.cs
+++ b/src/GeneticSharp.Infrastructure.Framework.UnitTests/Threading/StubTaskExecutor.cs
@@ -1,11 +1,13 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace GeneticSharp.Infrastructure.Framework.UnitTests.Threading
 {
     public class StubTaskExecutor : TaskExecutorBase
     {
-        public IList<Action> GetTasks()
+        public IList<Func<CancellationToken, ValueTask>> GetTasks()
         {
             return Tasks;
         }

--- a/src/GeneticSharp.Infrastructure.Framework/Threading/ITaskExecutor.cs
+++ b/src/GeneticSharp.Infrastructure.Framework/Threading/ITaskExecutor.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace GeneticSharp
 {
@@ -21,6 +23,11 @@ namespace GeneticSharp
         /// <c>true</c> if this instance is running; otherwise, <c>false</c>.
         /// </value>
         bool IsRunning { get; }
+
+        /// <summary>
+        /// Gets the cancellation token.
+        /// </summary>
+        CancellationToken CancellationToken { get; }
         #endregion
 
         #region Methods
@@ -28,7 +35,7 @@ namespace GeneticSharp
         /// Add the specified task to be executed.
         /// </summary>
         /// <param name="task">The task.</param>
-        void Add(Action task);
+        void Add(Func<CancellationToken, ValueTask> task);
 
         /// <summary>
         /// Clear all the tasks.

--- a/src/GeneticSharp.Infrastructure.Framework/Threading/LinearTaskExecutor.cs
+++ b/src/GeneticSharp.Infrastructure.Framework/Threading/LinearTaskExecutor.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 
 namespace GeneticSharp
 {
@@ -7,6 +8,22 @@ namespace GeneticSharp
     /// </summary>
     public class LinearTaskExecutor : TaskExecutorBase
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LinearTaskExecutor"/> class.
+        /// </summary>
+        public LinearTaskExecutor()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LinearTaskExecutor"/> class.
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        public LinearTaskExecutor(CancellationToken cancellationToken)
+            : base(cancellationToken)
+        {
+        }
+
         #region implemented abstract members of TaskExecutorBase
         /// <summary>
         /// Starts the tasks execution.
@@ -27,7 +44,7 @@ namespace GeneticSharp
                     return true;
                 }
 
-                Tasks[i]();
+                Tasks[i](CancellationToken).GetAwaiter().GetResult();
 
                 // If take more time expected on Timeout property,
                 // tehn stop thre running.

--- a/src/GeneticSharp.Infrastructure.Framework/Threading/ParallelTaskExecutor.cs
+++ b/src/GeneticSharp.Infrastructure.Framework/Threading/ParallelTaskExecutor.cs
@@ -81,6 +81,8 @@ namespace GeneticSharp
             finally
             {
                 ResetThreadPoolConfig(minWorker, minIOC, maxWorker, maxIOC);
+                CancellationTokenSource?.Dispose();
+                CancellationTokenSource = null;
                 IsRunning = false;
             }
         }

--- a/src/GeneticSharp.Infrastructure.Framework/Threading/ParallelTaskExecutor.cs
+++ b/src/GeneticSharp.Infrastructure.Framework/Threading/ParallelTaskExecutor.cs
@@ -18,6 +18,18 @@ namespace GeneticSharp
             MinThreads = 200;
             MaxThreads = 200;
         }
+
+        /// <summary>
+        /// Initializes a new instance of the
+        /// <see cref="T:GeneticSharp.Infrastructure.Framework.Threading.ParallelTaskExecutor"/> class.
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        public ParallelTaskExecutor(CancellationToken cancellationToken)
+            : base(cancellationToken)
+        {
+            MinThreads = 200;
+            MaxThreads = 200;
+        }
    
         /// <summary>
         /// Gets or sets the minimum threads.
@@ -47,12 +59,14 @@ namespace GeneticSharp
             try
             {
                 base.Start();
-                CancellationTokenSource = new CancellationTokenSource();
+                CancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(CancellationToken);
+                var token = CancellationTokenSource.Token;
                 var parallelTasks = new Task[Tasks.Count];
 
                 for (int i = 0; i < Tasks.Count; i++)
                 {
-                    parallelTasks[i] = Task.Run(Tasks[i], CancellationTokenSource.Token);
+                    var task = Tasks[i];
+                    parallelTasks[i] = Task.Run(async () => await task(token), token);
                 }
 
                 // Need to verify, because TimeSpan.MaxValue passed to Task.WaitAll throws a System.ArgumentOutOfRangeException.

--- a/src/GeneticSharp.Infrastructure.Framework/Threading/TaskExecutorBase.cs
+++ b/src/GeneticSharp.Infrastructure.Framework/Threading/TaskExecutorBase.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace GeneticSharp
 {
@@ -14,9 +16,19 @@ namespace GeneticSharp
         /// Initializes a new instance of the <see cref="GeneticSharp.TaskExecutorBase"/> class.
         /// </summary>
         protected TaskExecutorBase()
+            : this(CancellationToken.None)
         {
-            Tasks = new List<Action>();
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GeneticSharp.TaskExecutorBase"/> class.
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        protected TaskExecutorBase(CancellationToken cancellationToken)
+        {
+            Tasks = new List<Func<CancellationToken, ValueTask>>();
             Timeout = TimeSpan.MaxValue;
+            CancellationToken = cancellationToken;
         }
 
         /// <summary>
@@ -36,7 +48,12 @@ namespace GeneticSharp
         /// <summary>
         /// Gets the tasks.
         /// </summary>
-        protected IList<Action> Tasks { get; private set; }
+        protected IList<Func<CancellationToken, ValueTask>> Tasks { get; private set; }
+
+        /// <summary>
+        /// Gets the cancellation token.
+        /// </summary>
+        public CancellationToken CancellationToken { get; }
 
         /// <summary>
         /// Gets a value indicating whether this
@@ -44,12 +61,12 @@ namespace GeneticSharp
         /// </summary>
         /// <value><c>true</c> if stop requested; otherwise, <c>false</c>.</value>
         protected bool StopRequested { get; private set; }
-  
+
         /// <summary>
         /// Add the specified task to be executed.
         /// </summary>
         /// <param name="task">The task.</param>
-        public void Add(Action task)
+        public void Add(Func<CancellationToken, ValueTask> task)
         {
             Tasks.Add(task);
         }

--- a/src/GeneticSharp.Infrastructure.Framework/Threading/TaskExecutorExtensions.cs
+++ b/src/GeneticSharp.Infrastructure.Framework/Threading/TaskExecutorExtensions.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace GeneticSharp
+{
+    /// <summary>
+    /// Extension methods for <see cref="ITaskExecutor"/>.
+    /// </summary>
+    public static class TaskExecutorExtensions
+    {
+        /// <summary>
+        /// Add the specified synchronous task to be executed.
+        /// </summary>
+        /// <param name="executor">The task executor.</param>
+        /// <param name="task">The synchronous task.</param>
+        public static void Add(this ITaskExecutor executor, Action task)
+        {
+            executor.Add(ct => { task(); return default; });
+        }
+    }
+}

--- a/src/GeneticSharp.Infrastructure.Framework/Threading/TplTaskExecutor.cs
+++ b/src/GeneticSharp.Infrastructure.Framework/Threading/TplTaskExecutor.cs
@@ -60,6 +60,8 @@ namespace GeneticSharp
             }
             finally
             {
+                CancellationTokenSource?.Dispose();
+                CancellationTokenSource = null;
                 IsRunning = false;
             }
         }

--- a/src/GeneticSharp.Infrastructure.Framework/Threading/TplTaskExecutor.cs
+++ b/src/GeneticSharp.Infrastructure.Framework/Threading/TplTaskExecutor.cs
@@ -11,6 +11,22 @@ namespace GeneticSharp
     public class TplTaskExecutor : ParallelTaskExecutor
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="TplTaskExecutor"/> class.
+        /// </summary>
+        public TplTaskExecutor()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TplTaskExecutor"/> class.
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        public TplTaskExecutor(CancellationToken cancellationToken)
+            : base(cancellationToken)
+        {
+        }
+
+        /// <summary>
         /// Starts the tasks execution.
         /// </summary>
         /// <returns>If has reach the timeout or has been interrupted false, otherwise true.</returns>
@@ -19,28 +35,28 @@ namespace GeneticSharp
             try
             {
                 var startTime = DateTime.Now;
-                CancellationTokenSource = new CancellationTokenSource();
-                var result = new ParallelLoopResult();
+                CancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(CancellationToken);
+                var token = CancellationTokenSource.Token;
 
                 try
                 {
-                    result = Parallel.For(0, Tasks.Count, new ParallelOptions() { CancellationToken = CancellationTokenSource.Token }, (i, state) =>
-                    {
-                        // Execute the target function (fitness).
-                        Tasks[i]();
+                    Parallel.ForEachAsync(
+                        System.Linq.Enumerable.Range(0, Tasks.Count),
+                        new ParallelOptions() { CancellationToken = token },
+                        async (i, ct) =>
+                        {
+                            await Tasks[i](ct);
 
-                        // If cancellation token was requested OR take more time expected on Timeout property, 
-                        // then stop the running.
-                        if (CancellationTokenSource.IsCancellationRequested || (DateTime.Now - startTime) > Timeout)
-                            state.Break();
-                    });
+                            if ((DateTime.Now - startTime) > Timeout)
+                                CancellationTokenSource.Cancel();
+                        }).GetAwaiter().GetResult();
                 }
                 catch (OperationCanceledException)
                 {
-                    // Mute cancellation exception.
+                    return false;
                 }
 
-                return result.IsCompleted;
+                return true;
             }
             finally
             {


### PR DESCRIPTION
- Added `IAsyncFitness` interface for async fitness evaluation with `CancellationToken` support
- Changed `ITaskExecutor.Add` to accept `Func<CancellationToken, ValueTask>` for native async execution
- Added `IMutation.MinChromosomeLength` property (#109)